### PR TITLE
Fix assert.strictEqual argument order in counter.test.js.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ node_modules
 
 # Build directory
 dist
+
+# Editor temporary files
+*~
+\#*#
+.#*

--- a/tests/reducers/counter.test.js
+++ b/tests/reducers/counter.test.js
@@ -17,7 +17,7 @@ describe('counter reducer', () => {
     it('should increment state.count', () => {
       const previousValue = state.get('count');
       state = fireAction(counterReducer, state, INCREMENT_COUNTER);
-      assert.strictEqual(previousValue + 1, state.get('count'));
+      assert.strictEqual(state.get('count'), previousValue + 1);
     });
   });
 
@@ -25,7 +25,7 @@ describe('counter reducer', () => {
     it('should decrement state.count', () => {
       const previousValue = state.get('count');
       state = fireAction(counterReducer, state, DECREMENT_COUNTER);
-      assert.strictEqual(previousValue - 1, state.get('count'));
+      assert.strictEqual(state.get('count'), previousValue - 1);
     });
   });
 });


### PR DESCRIPTION
assert.strictEqual should have argument in order (actual, expected) rather than (expected, actual).

 - Add emacs temporary files to .gitignore