### PR TITLE
use stateTransformer instead of transformer

### DIFF
--- a/src/store/logger.js
+++ b/src/store/logger.js
@@ -3,7 +3,7 @@ import immutableToJS from '../utils/immutableToJS';
 
 export default createLogger({
   collapsed: true,
-  transformer: (state) => {
+  stateTransformer: (state) => {
     return immutableToJS(state);
   },
   predicate: (getState, { type }) => {


### PR DESCRIPTION
Otherwise you get the following console error on latest version of redux-logger.
```js
Option 'transformer' is deprecated, use stateTransformer instead
```