### PR TITLE
Add webpack notifier in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "mocha": "^2.3.3",
     "nodemon": "^1.8.1",
     "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^2.5.0"
+    "webpack-hot-middleware": "^2.5.0",
+    "webpack-notifier": "^1.2.1"
   },
   "dependencies": {
     "babel": "^5.5.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WebpackNotifierPlugin = require('webpack-notifier');
 
 function getEntrySources(sources) {
   if (process.env.NODE_ENV !== 'production') {
@@ -24,6 +25,9 @@ const basePlugins = [
 const devPlugins = [
   new webpack.HotModuleReplacementPlugin(),
   new webpack.NoErrorsPlugin(),
+  new WebpackNotifierPlugin({
+    title: 'React Redux Starter',
+  }),
 ];
 
 const prodPlugins = [


### PR DESCRIPTION
I stumbled across this little feature while playing with the source code that came with ng2-book. Seemed like a nice touch, it creates an OS notification on webpack build success or failure. Found it useful while in full screen mode of the editor. Both Windows and Mac are supported.

@SethDavenport @andrewdamelio @neilff let me know what you think when you get a chance, I'll recreate this in other starters if we like it.