### PR TITLE
Force heroku buildpack to nodejs

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,11 +2,12 @@
   "name":"react-redux-starter",
   "scripts":{},
   "env":{
-
     "NPM_CONFIG_PRODUCTION" : {
       "value":"false"
     }
-
   },
-  "addons":[]
+  "addons":[],
+  "buildpacks": [
+    { "url:" "heroku/nodejs" }
+  ]
 }


### PR DESCRIPTION
This is so Heroku doesn't see the robot test stuff and infer a python buildpack.

Connected to rangle/rangle-starter#26