### PR TITLE
Added postcss modules-local-by-default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "postcss-cssnext": "^2.4.0",
     "postcss-import": "^8.0.2",
     "postcss-loader": "^0.8.0",
+    "postcss-modules-local-by-default": "^1.0.1",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,5 +1,4 @@
 import ModalContent from './modal-content';
 import Modal from './modal';
-import './modal.css';
 
 export { ModalContent, Modal };

--- a/src/components/modal/modal-content.js
+++ b/src/components/modal/modal-content.js
@@ -1,8 +1,12 @@
 import React from 'react';
+import classNames from 'classnames';
+import { modal } from './modal.css';
 
 function ModalContent({ children }) {
+  const classDef = classNames('p2', 'z2', 'bg-white', 'relative', modal);
+
   return (
-    <div className="p2 z2 bg-white modal relative">
+    <div className={ classDef }>
       { children }
     </div>
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,7 @@ module.exports = {
 
   postcss: function postcssInit() {
     return [
+      require('postcss-modules-local-by-default'),
       require('postcss-import')({
         addDependencyTo: webpack,
       }),


### PR DESCRIPTION
Updated modal to use classname generated by local scope as an example.

for https://github.com/rangle/rangle-starter/issues/65

If this looks good I'll submit a PR for the React-TS starter too.