### PR TITLE
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "classnames": "^2.2.3",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.0",
+    "cssnano": "^3.5.2",
     "enzyme": "^2.2.0",
     "es5-shim": "^4.5.6",
     "es6-promise": "^3.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,28 @@ const plugins = basePlugins
   .concat(process.env.NODE_ENV === 'production' ? prodPlugins : [])
   .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
+const postcssBasePlugins = [
+  require('postcss-modules-local-by-default'),
+  require('postcss-import')({
+    addDependencyTo: webpack,
+  }),
+  require('postcss-cssnext')({
+    browsers: ['ie >= 8', 'last 2 versions'],
+  }),
+];
+const postcssDevPlugins = [];
+const postcssProdPlugins = [
+  require('cssnano')({
+    safe: true,
+    sourcemap: true,
+    autoprefixer:false,
+  }),
+];
+
+const postcssPlugins = postcssBasePlugins
+  .concat(process.env.NODE_ENV === 'production' ? postcssProdPlugins : [])
+  .concat(process.env.NODE_ENV === 'development' ? postcssDevPlugins : []);
+
 module.exports = {
   entry: {
     app: getEntrySources(['./src/index.js']),
@@ -94,14 +116,6 @@ module.exports = {
   },
 
   postcss: function postcssInit() {
-    return [
-      require('postcss-modules-local-by-default'),
-      require('postcss-import')({
-        addDependencyTo: webpack,
-      }),
-      require('postcss-cssnext')({
-        browsers: ['ie >= 8', 'last 2 versions'],
-      }),
-    ];
+    return postcssPlugins;
   },
 };


### PR DESCRIPTION
Add `cssnano` to end of `postcss` plugin chain to compress compiled `css` when `NODE_ENV=production` only.

Split `postcss` plugins into an explicit `base` set concatenated with a `dev` or `prod` set to achieve this behaviour. This follows the pattern used by the general `webpack` plugins.

Connected to rangle/rangle-starter#55