### PR TITLE
Updated webpack config to use SplitByPathPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "url-loader": "^0.5.6",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.14.1",
-    "webpack-hot-middleware": "^2.6.4"
+    "webpack-hot-middleware": "^2.6.4",
+    "webpack-split-by-path": "0.0.8"
   },
   "dependencies": {
     "express": "^4.13.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const proxy = require('./server/webpack-dev-proxy');
 const styleLintPlugin = require('stylelint-webpack-plugin');
+const SplitByPathPlugin = require('webpack-split-by-path');
 
 function getEntrySources(sources) {
   if (process.env.NODE_ENV !== 'production') {
@@ -18,6 +19,9 @@ const basePlugins = [
     __PRODUCTION__: process.env.NODE_ENV === 'production',
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
   }),
+  new SplitByPathPlugin([
+    { name: 'vendor', path: [__dirname + '/node_modules/'] }
+  ]),
   new HtmlWebpackPlugin({
     template: './src/index.html',
     inject: 'body',
@@ -71,17 +75,10 @@ const postcssPlugins = postcssBasePlugins
 module.exports = {
   entry: {
     app: getEntrySources(['./src/index.js']),
-    vendor: [
+    shims: [
       'es5-shim',
       'es6-shim',
       'es6-promise',
-      'react',
-      'react-redux',
-      'redux',
-      'redux-thunk',
-      'redux-logger',
-      'react-router',
-      'react-router-redux',
     ],
   },
 


### PR DESCRIPTION
Updated the webpack config file to use SplitByPathPlugin for all of the vendor files in node_modules except the shims.

Connected to rangle/rangle-starter#81