### PR TITLE
Import shims directly in index.js to make starter consistent with others

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+import 'es5-shim';
+import 'es6-shim';
+import 'es6-promise';
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,11 +75,6 @@ const postcssPlugins = postcssBasePlugins
 module.exports = {
   entry: {
     app: getEntrySources(['./src/index.js']),
-    shims: [
-      'es5-shim',
-      'es6-shim',
-      'es6-promise',
-    ],
   },
 
   output: {


### PR DESCRIPTION
Removed imports from webpack config. Updated to make consistent with other starters.

Tested in Chrome and IE.

Connected to rangle/rangle-starter#100