### PR TITLE
Update babel coverage plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,9 @@
   "presets": ["es2015", "react", "stage-0"],
   "env": {
     "test": {
-      "plugins": ["__coverage__"]
+      "plugins": [
+        ["__coverage__", { "ignore": "" }]
+      ]
     }
   }
 }

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,3 @@
+instrumentation:
+  include-all-sources: true
+  es-modules: true

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.1",
-    "babel-plugin-__coverage__": "^0.1111.1",
+    "babel-plugin-__coverage__": "^0.111111.11",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -9,26 +9,27 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "cross-env NODE_ENV=production webpack -p",
-    "clean": "rimraf dist/ coverage/",
-    "cover": "nyc check-coverage --lines 80 --functions 80 --branches 80",
+    "clean": "rimraf dist/",
     "dev": "cross-env NODE_ENV=development webpack-dev-server -d --inline --hot --progress --no-info",
     "lint": "npm run lint-js && npm run lint-css",
     "lint-css": "stylelint './src/**/*.css'",
     "lint-js": "eslint '**/*.js' --ignore-path .gitignore",
     "postinstall": "npm run build",
     "start": "cross-env NODE_ENV=production node server/node-server.js",
-    "pretest": "npm run clean && npm run lint",
+    "pretest": "npm run clean coverage/ & npm run lint",
     "test": "nyc --reporter=lcov --reporter=text-summary mocha",
-    "posttest": "npm run cover",
+    "posttest": "nyc check-coverage",
     "test:watch": "mocha --watch"
   },
   "nyc": {
     "exclude": [
       "**/*.test.js",
-      "test/entry.js",
-      "server/*",
-      "dist/*"
-    ]
+      "test/entry.js"
+    ],
+    "lines": 80,
+    "statements": 80,
+    "branches": 80,
+    "functions": 80
   },
   "devDependencies": {
     "autoprefixer": "^6.3.3",
@@ -73,7 +74,6 @@
     "history": "^2.0.1",
     "html-webpack-plugin": "^2.9.0",
     "immutable": "^3.7.5",
-    "istanbul": "^1.0.0-alpha",
     "json-loader": "^0.5.3",
     "mocha": "^2.3.3",
     "nyc": "^6.4.3",


### PR DESCRIPTION
Continuation of #165 and #133.

@SethDavenport this should pass CI, but unfortunately istanbul is still not instrumenting all the files, even though it's supposedly configured to via `.istanbul.yml`. Still, this does bring the coverage plugin up to date so it will make greenkeeper happy for now.

Connected to rangle/rangle-starter#92.