### PR TITLE
Optimize React in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,9 @@
       "plugins": [
         ["__coverage__", { "ignore": "" }]
       ]
+    },
+    "production": {
+      "plugins": ["transform-react-inline-elements", "transform-react-constant-elements"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.1",
     "babel-plugin-__coverage__": "^0.111111.11",
+    "babel-plugin-transform-react-constant-elements": "^6.8.0",
+    "babel-plugin-transform-react-inline-elements": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
This introduces two (key) production optimizations:
  - [inline elements
    transform](http://babeljs.io/docs/plugins/transform-react-inline-elements/):
Since React 0.14, `React.createElement` can be inlined by replacing
invocations with the equivalent ReactElements object. Hurray for less
function calls.
  - [constant elements
    transformer](http://babeljs.io/docs/plugins/transform-react-constant-elements/):

Also since React 0.14, ReactElements and their props are values (i.e.
elements with the same props are conceptually equivalent). As a result,
this optmization moves JSX with non-dynamic props out of the function
body so the exact same instance is returned for every render. Another hurray for
less allocations. As a bonus, this tells React not to bother diffing the
rest of the subtree, without having to set `shouldComponentUpdate`, for
an extra runtime performance boost.