### PR TITLE
feat(store/configure-store): Add routerMiddleware

### DIFF
--- a/src/store/configure-store.js
+++ b/src/store/configure-store.js
@@ -3,6 +3,8 @@ import { fromJS } from 'immutable';
 import persistState from 'redux-localstorage';
 import thunk from 'redux-thunk';
 import promiseMiddleware from '../middleware/promise-middleware';
+import { browserHistory } from 'react-router';
+import { routerMiddleware } from 'react-router-redux';
 import logger from './logger';
 import rootReducer from '../reducers';
 
@@ -18,6 +20,7 @@ function configureStore(initialState) {
 
 function _getMiddleware() {
   let middleware = [
+    routerMiddleware(browserHistory),
     promiseMiddleware,
     thunk,
   ];


### PR DESCRIPTION
This PR adds the `routerMiddleware` from `react-router-redux`. Now, the following will change the browser's route (before it didn't):

```JavaScript
import { push } from 'react-router-redux';

store.dispatch(push('/top'));
```