### PR TITLE
feat(store/configure-store): Use transit to serialize immutable session

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
     "style-loader": "^0.13.0",
     "stylelint": "^6.3.2",
     "stylelint-webpack-plugin": "^0.2.0",
+    "transit-immutable-js": "^0.6.0",
+    "transit-js": "^0.8.846",
     "url-loader": "^0.5.6",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.14.1",

--- a/src/store/configure-store.js
+++ b/src/store/configure-store.js
@@ -7,6 +7,7 @@ import { browserHistory } from 'react-router';
 import { routerMiddleware } from 'react-router-redux';
 import logger from './logger';
 import rootReducer from '../reducers';
+import transit from 'transit-immutable-js';
 
 function configureStore(initialState) {
   const store = compose(
@@ -57,11 +58,12 @@ function _getStorageConfig() {
   return {
     key: 'react-redux-seed',
     serialize: (store) => {
-      return store && store.session ?
-        JSON.stringify(store.session.toJS()) : store;
+      return store && store.session
+        ? transit.toJSON(store.session)
+        : store;
     },
-    deserialize: (state) => ({
-      session: state ? fromJS(JSON.parse(state)) : fromJS({}),
+    deserialize: (str) => ({
+      session: str ? transit.fromJSON(str) : fromJS({}),
     }),
   };
 }


### PR DESCRIPTION
### Description
ImmutableJS's `Iterable.prototype.toJS` and `Immutable.fromJS` aren't reliable for serializing and deserializing data structures. For example:

```JavaScript
const shouldBeASet = Immutable.fromJS(Immutable.Set.of(1,2,3,4).toJS());
Immutable.Set.isSet(shouldBeASet); // false
```

[transit-immutable-js](https://github.com/glenjamin/transit-immutable-js) supports serializing objects that are a mix of Immutable and vanilla objects.