### PR TITLE
Applied recent lessons learned for Autoprefixer

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,3 @@
+Last 2 versions
+Safari >= 8
+IE >= 9

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
       { test: /\.js$/, loader: 'eslint-loader' },
     ],
     loaders: [
-      { test: /\.css$/, loader: 'style-loader!css-loader!postcss-loader' },
+      { test: /\.css$/, loader: 'style-loader!css?-minimize!postcss' },
       { test: /\.js$/, loaders: ['react-hot', 'babel'], exclude: /node_modules/ },
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.(png|jpg|jpeg|gif|svg)$/, loader: 'url-loader?prefix=img/&limit=5000' },

--- a/webpack/postcss.js
+++ b/webpack/postcss.js
@@ -5,9 +5,7 @@ const postcssBasePlugins = [
   require('postcss-import')({
     addDependencyTo: webpack,
   }),
-  require('postcss-cssnext')({
-    browsers: ['ie >= 9', 'last 2 versions'],
-  }),
+  require('postcss-cssnext'),
 ];
 const postcssDevPlugins = [];
 const postcssProdPlugins = [


### PR DESCRIPTION
Work around a well known webpack.UglifyJSPlugin behaviour that strips -webpack prefixes regardless of autoprefixer settings.

Separate the browser version specs into a browserslist file.

Connected to rangle/rangle-starter#137